### PR TITLE
Fix cmake build issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
 
             -   name: Configure
                 run: |
-                    cmake --std=c++14 -S. -Bbuild -DCMAKE_BUILD_TYPE=Debug
+                    cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Debug
             -   name: Build
                 run: |
-                    cmake --std=c++14 --build build --config Debug
+                    cmake --build build --config Debug
             -   name: Test
                 run: |
                     cd build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_CXX_STANDARD 17)
+
 add_library(NeetCode arrays/private/ValidAnagram.cpp arrays/public/ValidAnagram.h arrays/private/TwoSum.cpp arrays/public/TwoSum.h arrays/private/GroupAnagrams.cpp arrays/public/GroupAnagrams.h)
 
 target_sources(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_CXX_STANDARD 17)
+
 include(FetchContent)
 FetchContent_Declare(
         gtest

--- a/test/arrays/GroupAnagrams_test.cpp
+++ b/test/arrays/GroupAnagrams_test.cpp
@@ -14,7 +14,8 @@ TEST(GroupAnagrams, exmaple) {
     }
     std::sort(expected.begin(), expected.end(),
               [](const std::vector<std::string> &a, const std::vector<std::string> &b) {
-                  return a.size() - b.size();
+                  return (a.size() < b.size()) ||
+                         (!(a.size() > b.size()) && (a.size() < b.size()));
               });
 
     std::vector<std::string> input = {"eat", "tea", "tan", "ate", "nat", "bat"};
@@ -24,7 +25,8 @@ TEST(GroupAnagrams, exmaple) {
     }
     std::sort(actual.begin(), actual.end(),
               [](const std::vector<std::string> &a, const std::vector<std::string> &b) {
-                  return a.size() - b.size();
+                  return (a.size() < b.size()) ||
+                         (!(a.size() > b.size()) && (a.size() < b.size()));
               });
 
     EXPECT_EQ(expected, actual) << "Anagrams grouped incorrectly";


### PR DESCRIPTION
I needed to change the comparator here https://github.com/williamhammond/NeetCode/pull/1/files#diff-679543a0583651ae7138da6e8a1925bde800d557db136984a777d03e2679e3bdR28-R29 because the Microsoft visual studio compiler needs strict weak ordering https://stackoverflow.com/questions/9648100/using-own-comparator-operator-for-map-giving-error-in-case-if-key-not-found. 